### PR TITLE
Set expected multilevel switch report msg to >=6

### DIFF
--- a/src/cmds/basic.rs
+++ b/src/cmds/basic.rs
@@ -27,7 +27,7 @@ impl Basic {
 
         // the message need to be exact 6 digits long
         if msg.len() != 6 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check the CommandClass and command

--- a/src/cmds/info.rs
+++ b/src/cmds/info.rs
@@ -29,7 +29,7 @@ impl NodeInfo {
             // get the type fro the vector
             let m = msg
                 .get(i as usize)
-                .ok_or(Error::new(ErrorKind::UnknownZWave, "Message is to short"))?;
+                .ok_or(Error::new(ErrorKind::UnknownZWave, "Message is too short"))?;
             let m = m.clone();
 
             // when the device is unkown continue
@@ -55,7 +55,7 @@ impl NodeInfo {
             // get the command for the vector
             let m = msg
                 .get(i as usize)
-                .ok_or(Error::new(ErrorKind::UnknownZWave, "Message is to short"))?;
+                .ok_or(Error::new(ErrorKind::UnknownZWave, "Message is too short"))?;
             let m = m.clone();
 
             // try to convert the command

--- a/src/cmds/meter.rs
+++ b/src/cmds/meter.rs
@@ -177,7 +177,7 @@ impl Meter {
 
         // the message need to be exact 6 digits long
         if msg.len() < 8 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check the CommandClass and command

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -235,7 +235,7 @@ impl Message {
 
         // check if the data has enough entries
         if data.len() < 3 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check if the length flag matches

--- a/src/cmds/powerlevel.rs
+++ b/src/cmds/powerlevel.rs
@@ -85,7 +85,7 @@ impl PowerLevel {
 
         // the message need to be exact 7 digits long
         if msg.len() != 7 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check the CommandClass and command
@@ -170,7 +170,7 @@ impl PowerLevel {
         if msg.len() != 9 {
             return Err(Error::new(
                 ErrorKind::UnknownZWave,
-                format!("Message is to short: {:?}", msg),
+                format!("Message is too short: {:?}", msg),
             ));
         }
 

--- a/src/cmds/switch_binary.rs
+++ b/src/cmds/switch_binary.rs
@@ -45,7 +45,7 @@ impl SwitchBinary {
 
         // the message need to be exact 6 digits long
         if msg.len() != 6 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check the CommandClass and command

--- a/src/cmds/switch_multilevel.rs
+++ b/src/cmds/switch_multilevel.rs
@@ -45,9 +45,10 @@ impl SwitchMultilevel {
         // get the message
         let msg = msg.into();
 
-        // the message need to be at least 7 digits long
-        if msg.len() < 7 {
-            return Err(Error::new(ErrorKind::UnknownZWave, "Message is to short"));
+        // the message need to be at least 6 digits long. Version 4 may return
+        // more data, but not currently supported. 
+        if msg.len() < 6 {
+            return Err(Error::new(ErrorKind::UnknownZWave, "Message is too short"));
         }
 
         // check the CommandClass and command


### PR DESCRIPTION
I think this is correct. Version 4 appears to support two more bytes for
target value and duration, but I don't have any devices that support it
to test with.